### PR TITLE
✨ zv: support ser/de of values directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,6 +1239,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset 0.9.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2610,6 +2626,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "glib",
+ "nom",
  "rand",
  "serde",
  "serde_bytes",

--- a/zvariant/Cargo.toml
+++ b/zvariant/Cargo.toml
@@ -34,6 +34,7 @@ time = { version = "0.3.36", features = ["serde"], optional = true }
 chrono = { version = "0.4.38", features = [
     "serde",
 ], default-features = false, optional = true }
+nom = { version = "7.1.3" }
 
 [dev-dependencies]
 serde_json = "1.0.116"

--- a/zvariant/src/dict.rs
+++ b/zvariant/src/dict.rs
@@ -75,6 +75,11 @@ impl<'k, 'v> Dict<'k, 'v> {
         Ok(())
     }
 
+    /// Remove the first entry
+    pub fn remove(&mut self) -> Option<(Value<'k>, Value<'v>)> {
+        self.map.pop_first()
+    }
+
     /// Get the value for the given key.
     pub fn get<'d, K, V>(&'d self, key: &'k K) -> Result<Option<V>, Error>
     where
@@ -322,4 +327,22 @@ fn create_signature(
     value_signature: &Signature<'_>,
 ) -> Signature<'static> {
     Signature::from_string_unchecked(format!("a{{{key_signature}{value_signature}}}",))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn remove() {
+        let mut dict = Dict::new(signature_string!("s"), signature_string!("i"));
+        dict.add("a", 1).unwrap();
+        dict.add("b", 2).unwrap();
+        dict.add("c", 3).unwrap();
+
+        assert_eq!(dict.remove(), Some((Value::new("a"), Value::new(1))));
+        assert_eq!(dict.remove(), Some((Value::new("b"), Value::new(2))));
+        assert_eq!(dict.remove(), Some((Value::new("c"), Value::new(3))));
+        assert_eq!(dict.remove(), None);
+    }
 }

--- a/zvariant/src/dict.rs
+++ b/zvariant/src/dict.rs
@@ -7,7 +7,7 @@ use std::{
 use serde::ser::{Serialize, SerializeSeq, SerializeStruct, Serializer};
 use static_assertions::assert_impl_all;
 
-use crate::{value_display_fmt, Basic, DynamicType, Error, Signature, Type, Value};
+use crate::{value::value_display_fmt, Basic, DynamicType, Error, Signature, Type, Value};
 
 /// A helper type to wrap dictionaries in a [`Value`].
 ///

--- a/zvariant/src/error.rs
+++ b/zvariant/src/error.rs
@@ -38,7 +38,6 @@ impl fmt::Display for MaxDepthExceeded {
 pub enum Error {
     /// Generic error. All serde errors gets transformed into this variant.
     Message(String),
-
     /// Wrapper for [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html)
     InputOutput(Arc<io::Error>),
     /// Type conversions errors.
@@ -60,6 +59,8 @@ pub enum Error {
     OutOfBounds,
     /// The maximum allowed depth for containers in encoding was exceeded.
     MaxDepthExceeded(MaxDepthExceeded),
+    /// An unexpected value with no corresponding signature was encountered.
+    UnexpectedValue(String)
 }
 
 assert_impl_all!(Error: Send, Sync, Unpin);
@@ -74,6 +75,7 @@ impl PartialEq for Error {
             (Error::PaddingNot0(p), Error::PaddingNot0(other)) => p == other,
             (Error::UnknownFd, Error::UnknownFd) => true,
             (Error::MaxDepthExceeded(max1), Error::MaxDepthExceeded(max2)) => max1 == max2,
+            (Error::UnexpectedValue(left), Error::UnexpectedValue(right)) => left == right,
             (_, _) => false,
         }
     }
@@ -115,6 +117,7 @@ impl fmt::Display for Error {
                 "Out of bounds range specified",
             ),
             Error::MaxDepthExceeded(max) => write!(f, "{max}"),
+            Error::UnexpectedValue(s) => write!(f, "Unexpected value: {s}"),
         }
     }
 }
@@ -137,6 +140,7 @@ impl Clone for Error {
             }
             Error::OutOfBounds => Error::OutOfBounds,
             Error::MaxDepthExceeded(max) => Error::MaxDepthExceeded(*max),
+            Error::UnexpectedValue(s) => Error::UnexpectedValue(s.clone()),
         }
     }
 }

--- a/zvariant/src/lib.rs
+++ b/zvariant/src/lib.rs
@@ -73,7 +73,7 @@ mod optional;
 pub use crate::optional::*;
 
 mod value;
-pub use value::*;
+pub use value::{from_value, Value};
 
 mod serialize_value;
 pub use serialize_value::*;

--- a/zvariant/src/maybe.rs
+++ b/zvariant/src/maybe.rs
@@ -24,6 +24,12 @@ impl<'a> Maybe<'a> {
         &self.value
     }
 
+    /// Transform this into an `Option<Value>` consuming
+    /// the `Maybe` in the process.
+    pub fn into_inner(mut self) -> Option<Value<'a>> {
+        self.value.take()
+    }
+
     /// Create a new Just (Some) `Maybe`.
     pub fn just(value: Value<'a>) -> Self {
         let value_signature = value.value_signature().to_owned();
@@ -205,4 +211,20 @@ impl<'a> Serialize for Maybe<'a> {
 
 fn create_signature(value_signature: &Signature<'_>) -> Signature<'static> {
     Signature::from_string_unchecked(format!("m{value_signature}"))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn into_inner() {
+        let maybe = Maybe::just(Value::new(42));
+        let value = maybe.into_inner();
+        assert_eq!(value, Some(Value::new(42)));
+
+        let maybe = Maybe::nothing(signature_string!("i"));
+        let value = maybe.into_inner();
+        assert_eq!(value, None);
+    }
 }

--- a/zvariant/src/maybe.rs
+++ b/zvariant/src/maybe.rs
@@ -2,7 +2,7 @@ use serde::ser::{Serialize, Serializer};
 use static_assertions::assert_impl_all;
 use std::fmt::Display;
 
-use crate::{value_display_fmt, Error, Signature, Type, Value};
+use crate::{value::value_display_fmt, Error, Signature, Type, Value};
 
 /// A helper type to wrap `Option<T>` (GVariant's Maybe type) in [`Value`].
 ///

--- a/zvariant/src/structure.rs
+++ b/zvariant/src/structure.rs
@@ -7,8 +7,9 @@ use static_assertions::assert_impl_all;
 use std::fmt::{Display, Write};
 
 use crate::{
-    signature_parser::SignatureParser, value::SignatureSeed, value_display_fmt, DynamicDeserialize,
-    DynamicType, OwnedValue, Signature, Value,
+    signature_parser::SignatureParser,
+    value::{value_display_fmt, SignatureSeed},
+    DynamicDeserialize, DynamicType, OwnedValue, Signature, Value,
 };
 
 /// Use this to efficiently build a [`Structure`].

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -1,4 +1,5 @@
 pub mod parsed_signature;
+pub mod ser;
 
 use core::{
     cmp::Ordering,

--- a/zvariant/src/value.rs
+++ b/zvariant/src/value.rs
@@ -1,3 +1,5 @@
+pub mod parsed_signature;
+
 use core::{
     cmp::Ordering,
     fmt::{Display, Write},

--- a/zvariant/src/value/de.rs
+++ b/zvariant/src/value/de.rs
@@ -1,0 +1,743 @@
+//! Deserialization of `Value` into Rust types.
+//!
+//! This modules provides a `Deserializer` implementation for
+//! `Value` which allows for deserializing a `Value` into
+//! Rust types.
+//!
+//! Normally this module is not used directly, but is instead
+//! invoked via the `zvariant::from_value` method provied
+//! by this create. This deserializer can also be constructed
+//! by calling `Value::into_deserializer`.
+
+use crate::{Array, Dict, Value};
+use serde::{
+    de::{
+        EnumAccess, Error, IntoDeserializer, MapAccess, SeqAccess, Unexpected, VariantAccess,
+        Visitor,
+    },
+    Deserializer,
+};
+use std::{collections::VecDeque, os::fd::AsRawFd};
+
+macro_rules! deserialize_method {
+    ($method:ident($($arg:ident: $type:ty),*)) => {
+        #[inline]
+        fn $method<V>(self, $($arg: $type,)* visitor: V) -> Result<V::Value, crate::Error>
+        where
+            V: Visitor<'de>,
+        {
+            match self.value {
+                Value::Value(value) => value.into_deserializer().$method($($arg,)* visitor),
+                _ => self.deserialize_any(visitor)
+            }
+        }
+    }
+}
+
+/// Deserialize a `Value` into a Rust type.
+pub struct ValueDeserializer<'de> {
+    value: Value<'de>,
+}
+
+impl<'de> ValueDeserializer<'de> {
+    pub fn new(value: Value<'de>) -> Self {
+        Self { value }
+    }
+}
+
+impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
+    type Error = crate::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::Visitor<'de>,
+    {
+        match self.value {
+            Value::U8(v) => visitor.visit_u8(v),
+            Value::Bool(v) => visitor.visit_bool(v),
+            Value::I16(v) => visitor.visit_i16(v),
+            Value::U16(v) => visitor.visit_u16(v),
+            Value::I32(v) => visitor.visit_i32(v),
+            Value::Fd(v) => visitor.visit_i32(v.as_raw_fd()),
+            Value::U32(v) => visitor.visit_u32(v),
+            Value::I64(v) => visitor.visit_i64(v),
+            Value::U64(v) => visitor.visit_u64(v),
+            Value::F64(v) => visitor.visit_f64(v),
+            Value::Str(v) => visitor.visit_str(v.as_str()),
+            Value::Signature(sig) => visitor.visit_str(sig.as_str()),
+            Value::ObjectPath(path) => visitor.visit_str(path.as_str()),
+            Value::Value(value) => visitor.visit_map(ValueAccess::new(*value)),
+            Value::Array(array) => visitor.visit_seq(ArrayAccess::new(array)),
+            Value::Dict(dict) => visitor.visit_map(DictAccess::new(dict)),
+            Value::Structure(structure) => {
+                visitor.visit_seq(StructureAccess::new(structure.into_fields().into()))
+            }
+            #[cfg(feature = "gvariant")]
+            Value::Maybe(value) => {
+                if let Some(value) = value.into_inner() {
+                    visitor.visit_some(value.into_deserializer())
+                } else {
+                    visitor.visit_none()
+                }
+            }
+        }
+    }
+
+    deserialize_method!(deserialize_bool());
+    deserialize_method!(deserialize_i8());
+    deserialize_method!(deserialize_i16());
+    deserialize_method!(deserialize_i32());
+    deserialize_method!(deserialize_i64());
+    deserialize_method!(deserialize_u8());
+    deserialize_method!(deserialize_u16());
+    deserialize_method!(deserialize_u32());
+    deserialize_method!(deserialize_u64());
+    deserialize_method!(deserialize_f32());
+    deserialize_method!(deserialize_f64());
+    deserialize_method!(deserialize_str());
+    deserialize_method!(deserialize_string());
+    deserialize_method!(deserialize_bytes());
+    deserialize_method!(deserialize_byte_buf());
+    deserialize_method!(deserialize_unit());
+    deserialize_method!(deserialize_unit_struct(n: &'static str));
+    deserialize_method!(deserialize_seq());
+    deserialize_method!(deserialize_map());
+    deserialize_method!(deserialize_tuple(n: usize));
+    deserialize_method!(deserialize_struct(n: &'static str, f: &'static [&'static str]));
+    deserialize_method!(deserialize_identifier());
+    deserialize_method!(deserialize_ignored_any());
+
+    fn deserialize_option<V>(self, #[allow(unused_variables)] visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            #[cfg(feature = "gvariant")]
+            Value::Maybe(maybe) => {
+                if let Some(value) = maybe.into_inner() {
+                    visitor.visit_some(value.into_deserializer())
+                } else {
+                    visitor.visit_none()
+                }
+            }
+
+            #[cfg(feature = "option-as-array")]
+            Value::Array(mut array) => {
+                if array.is_empty() {
+                    visitor.visit_none()
+                } else if array.len() == 1 {
+                    let elem = array.remove().unwrap();
+                    visitor.visit_some(elem.into_deserializer())
+                } else {
+                    Err(crate::Error::invalid_value(
+                        Unexpected::Seq,
+                        &"0 or 1 elements for an optional type",
+                    ))
+                }
+            }
+
+            value => Err(crate::Error::invalid_value(
+                value.unexpected(),
+                &"an optional type",
+            )),
+        }
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if let Value::Value(inner) = self.value {
+            return inner
+                .into_deserializer()
+                .deserialize_newtype_struct(name, visitor);
+        }
+
+        match name {
+            "zvariant::ObjectPath" => match self.value {
+                Value::ObjectPath(object_path) => {
+                    visitor.visit_newtype_struct(object_path.into_deserializer())
+                }
+                value => Err(Error::invalid_value(value.unexpected(), &"an object path")),
+            },
+            "zvariant::Signature" => match self.value {
+                Value::Signature(sig) => visitor.visit_newtype_struct(sig.into_deserializer()),
+                value => Err(Error::invalid_value(value.unexpected(), &"a signature")),
+            },
+            _ => self.deserialize_any(visitor),
+        }
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::U8(byte) => visitor.visit_char(byte as char),
+            Value::Str(string) => {
+                if string.len() == 1 {
+                    visitor.visit_char(string.chars().next().unwrap())
+                } else {
+                    Err(Error::invalid_value(
+                        Unexpected::Str(string.as_str()),
+                        &"a single character",
+                    ))
+                }
+            }
+            Value::Value(value) => value.into_deserializer().deserialize_char(visitor),
+            value => Err(crate::Error::invalid_value(value.unexpected(), &"a char")),
+        }
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Structure(structure) => {
+                visitor.visit_enum(StructureEnumAccess::new(structure.into_fields().into()))
+            }
+            value => Err(Error::invalid_value(value.unexpected(), &"an enum")),
+        }
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.value {
+            Value::Structure(structure) => {
+                visitor.visit_seq(StructureAccess::new(structure.into_fields().into()))
+            }
+            Value::Array(array) => visitor.visit_seq(ArrayAccess::new(array)),
+            value => Err(Error::invalid_value(value.unexpected(), &"a tuple struct")),
+        }
+    }
+}
+
+/// The internal state of a `ValueAccess`
+enum ValueAccessState {
+    /// The signature is being read
+    ReadingSignature,
+
+    /// The value is being read
+    ReadingValue,
+
+    /// The deserialization is done and
+    /// there are no more values to read
+    Done,
+}
+
+/// Deserialize a `Value` from a DBus/GVariant variant.
+struct ValueAccess<'de> {
+    value: Value<'de>,
+    state: ValueAccessState,
+}
+
+impl<'de> ValueAccess<'de> {
+    pub fn new(value: Value<'de>) -> Self {
+        Self {
+            value,
+            state: ValueAccessState::ReadingSignature,
+        }
+    }
+}
+
+impl<'de> MapAccess<'de> for ValueAccess<'de> {
+    type Error = crate::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: serde::de::DeserializeSeed<'de>,
+    {
+        match self.state {
+            ValueAccessState::ReadingSignature => seed
+                .deserialize("zvariant::Value::Signature".into_deserializer())
+                .map(Some),
+            ValueAccessState::ReadingValue => seed
+                .deserialize("zvariant::Value::Value".into_deserializer())
+                .map(Some),
+            ValueAccessState::Done => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::DeserializeSeed<'de>,
+    {
+        match self.state {
+            ValueAccessState::ReadingSignature => {
+                self.state = ValueAccessState::ReadingValue;
+                seed.deserialize(self.value.value_signature().into_deserializer())
+            }
+            ValueAccessState::ReadingValue => {
+                self.state = ValueAccessState::Done;
+                seed.deserialize(self.value.try_clone()?.into_deserializer())
+            }
+            ValueAccessState::Done => unreachable!(),
+        }
+    }
+}
+
+/// Deserialize a sequence of values from a given `Array`.
+struct ArrayAccess<'de> {
+    array: Array<'de>,
+}
+
+impl<'de> ArrayAccess<'de> {
+    pub fn new(array: Array<'de>) -> Self {
+        Self { array }
+    }
+}
+
+impl<'de> SeqAccess<'de> for ArrayAccess<'de> {
+    type Error = crate::Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: serde::de::DeserializeSeed<'de>,
+    {
+        if let Some(item) = self.array.remove() {
+            seed.deserialize(item.into_deserializer()).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// Deserialize a map of values from a given `Dict`
+struct DictAccess<'de> {
+    dict: Dict<'de, 'de>,
+    next_value: Option<Value<'de>>,
+}
+
+impl<'de> DictAccess<'de> {
+    pub fn new(dict: Dict<'de, 'de>) -> Self {
+        Self {
+            dict,
+            next_value: None,
+        }
+    }
+}
+
+impl<'de> MapAccess<'de> for DictAccess<'de> {
+    type Error = crate::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: serde::de::DeserializeSeed<'de>,
+    {
+        if let Some((key, value)) = self.dict.remove() {
+            self.next_value = Some(value);
+            seed.deserialize(key.into_deserializer()).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: serde::de::DeserializeSeed<'de>,
+    {
+        if let Some(value) = self.next_value.take() {
+            seed.deserialize(value.into_deserializer())
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+/// Deserialize a given sequence of fields taken from a `Structure`
+/// into a rust sequence
+struct StructureAccess<'de> {
+    fields: VecDeque<Value<'de>>,
+}
+
+impl<'de> StructureAccess<'de> {
+    pub fn new(fields: VecDeque<Value<'de>>) -> Self {
+        Self { fields }
+    }
+}
+
+impl<'de> SeqAccess<'de> for StructureAccess<'de> {
+    type Error = crate::Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+    where
+        T: serde::de::DeserializeSeed<'de>,
+    {
+        if let Some(item) = self.fields.pop_front() {
+            seed.deserialize(item.into_deserializer()).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// Deserialize a given sequence of fields taken from a `Structure`
+/// into a rust Enum
+struct StructureEnumAccess<'de> {
+    fields: VecDeque<Value<'de>>,
+}
+
+impl<'de> StructureEnumAccess<'de> {
+    pub fn new(fields: VecDeque<Value<'de>>) -> Self {
+        Self { fields }
+    }
+}
+
+impl<'de> EnumAccess<'de> for StructureEnumAccess<'de> {
+    type Error = crate::Error;
+    type Variant = StructureEnumAccess<'de>;
+
+    fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: serde::de::DeserializeSeed<'de>,
+    {
+        if let Some(name_field) = self.fields.pop_front() {
+            let result = seed.deserialize(name_field.into_deserializer())?;
+            Ok((result, self))
+        } else {
+            Err(crate::Error::missing_field("Enum Discriminator"))
+        }
+    }
+}
+
+impl<'de> VariantAccess<'de> for StructureEnumAccess<'de> {
+    type Error = crate::Error;
+
+    fn unit_variant(mut self) -> Result<(), Self::Error> {
+        if let Some(field) = self.fields.pop_front() {
+            Err(crate::Error::invalid_value(
+                field.unexpected(),
+                &"Expected a unit variant",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn newtype_variant_seed<T>(mut self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: serde::de::DeserializeSeed<'de>,
+    {
+        if let Some(field) = self.fields.pop_front() {
+            seed.deserialize(field.into_deserializer())
+        } else {
+            Err(crate::Error::missing_field("expected enum data"))
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_seq(StructureAccess::new(self.fields))
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_seq(StructureAccess::new(self.fields))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::{ObjectPath, OwnedObjectPath, OwnedSignature, Signature, StructureBuilder};
+    use serde::Deserialize;
+
+    #[test]
+    fn deserialize_i16() {
+        let de = Value::I16(42).into_deserializer();
+        let result: i16 = i16::deserialize(de).expect("Should find an i16");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_i32() {
+        let de = Value::I32(42).into_deserializer();
+        let result: i32 = i32::deserialize(de).expect("Should find an i32");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_i64() {
+        let de = Value::I64(42).into_deserializer();
+        let result: i64 = i64::deserialize(de).expect("Should find an i64");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_u8() {
+        let de = Value::U8(42).into_deserializer();
+        let result: u8 = u8::deserialize(de).expect("Should find an u8");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_u16() {
+        let de = Value::U16(42).into_deserializer();
+        let result: u16 = u16::deserialize(de).expect("Should find an u16");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_u32() {
+        let de = Value::U32(42).into_deserializer();
+        let result: u32 = u32::deserialize(de).expect("Should find an u32");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_u64() {
+        let de = Value::U64(42).into_deserializer();
+        let result: u64 = u64::deserialize(de).expect("Should find an u64");
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_f64() {
+        let de = Value::F64(3.14).into_deserializer();
+        let result: f64 = f64::deserialize(de).expect("Should find an f64");
+        assert_eq!(result, 3.14);
+    }
+
+    #[test]
+    fn deserialize_char() {
+        let de = Value::U8(b'a').into_deserializer();
+        let result: char = char::deserialize(de).expect("Should find a char");
+        assert_eq!(result, 'a');
+    }
+
+    #[test]
+    fn deserialize_str() {
+        let de = Value::Str("hello".into()).into_deserializer();
+        let result: String = String::deserialize(de).expect("Should find a string");
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn deserialize_signature() {
+        let de = Value::Signature(Signature::from_str_unchecked("a{sv}")).into_deserializer();
+        let result: Signature<'_> = Signature::deserialize(de).expect("Should find a signature");
+        assert_eq!(result.as_str(), "a{sv}");
+    }
+
+    #[test]
+    fn deserialize_object_path() {
+        let de = Value::ObjectPath(ObjectPath::from_str_unchecked("/hello")).into_deserializer();
+        let result: ObjectPath<'_> =
+            ObjectPath::deserialize(de).expect("Should find an object path");
+        assert_eq!(result.as_str(), "/hello");
+    }
+
+    #[test]
+    fn deserialize_array() {
+        let array = Array::from(vec![42, 43]);
+        let de = Value::Array(array).into_deserializer();
+        let result: Vec<u32> = Vec::deserialize(de).expect("Should find an array");
+        assert_eq!(result, vec![42, 43]);
+    }
+
+    #[test]
+    fn deserialize_dict() {
+        let mut dict = Dict::new(
+            Signature::from_str_unchecked("s"),
+            Signature::from_str_unchecked("i"),
+        );
+
+        dict.add("hello", 42).expect("Should append");
+        dict.add("world", 43).expect("Should append");
+
+        let de = Value::Dict(dict).into_deserializer();
+        let result: std::collections::HashMap<String, u32> =
+            std::collections::HashMap::deserialize(de).expect("Should find a dict");
+        assert_eq!(result.get("hello"), Some(&42));
+        assert_eq!(result.get("world"), Some(&43));
+    }
+
+    #[test]
+    fn deserialize_dict_struct() {
+        #[derive(Deserialize)]
+        struct MyStruct {
+            a: OwnedObjectPath,
+            b: OwnedSignature,
+        }
+
+        let mut dict = Dict::new(
+            Signature::from_str_unchecked("s"),
+            Signature::from_str_unchecked("v"),
+        );
+
+        dict.add(
+            "a",
+            Value::new(ObjectPath::from_static_str_unchecked("/hello")),
+        )
+        .expect("Should append");
+        dict.add("b", Value::new(Signature::from_static_str_unchecked("s")))
+            .expect("Should append");
+
+        let de = Value::Dict(dict).into_deserializer();
+        let result: MyStruct = MyStruct::deserialize(de).expect("Should find a struct");
+        assert_eq!(result.a.as_str(), "/hello");
+        assert_eq!(result.b.as_str(), "s");
+    }
+
+    #[test]
+    fn deserialize_dict_map() {
+        let mut dict = Dict::new(
+            Signature::from_str_unchecked("s"),
+            Signature::from_str_unchecked("s"),
+        );
+
+        dict.add("a", "hello").expect("Should append");
+        dict.add("b", "world").expect("Should append");
+
+        let de = Value::Dict(dict).into_deserializer();
+        let result: HashMap<String, String> =
+            HashMap::<String, String>::deserialize(de).expect("Should find a dict");
+        assert_eq!(result["a"].as_str(), "hello");
+        assert_eq!(result["b"].as_str(), "world");
+    }
+
+    #[test]
+    fn deserialize_newtype_struct() {
+        #[derive(Deserialize)]
+        struct MyStruct(i32);
+
+        let structure = StructureBuilder::new().add_field(42i32).build();
+
+        let de = Value::Structure(structure).into_deserializer();
+        let result: MyStruct = MyStruct::deserialize(de).unwrap();
+        assert_eq!(result.0, 42);
+    }
+
+    #[test]
+    fn deserialize_newtype_variant() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        enum MyEnum {
+            A(i32),
+            B(i32),
+        }
+
+        {
+            let structure = StructureBuilder::new()
+                .add_field("A")
+                .add_field(1i32)
+                .build();
+
+            let input = Value::Structure(structure);
+
+            let de = input.into_deserializer();
+            let output: MyEnum = MyEnum::deserialize(de).unwrap();
+
+            assert_eq!(output, MyEnum::A(1));
+        }
+
+        {
+            let structure = StructureBuilder::new()
+                .add_field("B")
+                .add_field(2i32)
+                .build();
+
+            let input = Value::Structure(structure);
+
+            let de = input.into_deserializer();
+            let output: MyEnum = MyEnum::deserialize(de).unwrap();
+
+            assert_eq!(output, MyEnum::B(2));
+        }
+    }
+
+    #[test]
+    fn deserialize_unit_variant() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        enum MyEnum {
+            A,
+            B,
+        }
+
+        {
+            let structure = StructureBuilder::new().add_field("A").build();
+
+            let input = Value::Structure(structure);
+
+            let de = input.into_deserializer();
+            let output: MyEnum = MyEnum::deserialize(de).unwrap();
+
+            assert_eq!(output, MyEnum::A);
+        }
+
+        {
+            let structure = StructureBuilder::new().add_field("B").build();
+
+            let input = Value::Structure(structure);
+
+            let de = input.into_deserializer();
+            let output: MyEnum = MyEnum::deserialize(de).unwrap();
+
+            assert_eq!(output, MyEnum::B);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "gvariant")]
+    fn deserialize_maybe_some() {
+        use crate::Maybe;
+        let input = Value::Maybe(Maybe::just(Value::U8(1)));
+        let de = input.into_deserializer();
+        let output: Option<u8> = Option::deserialize(de).unwrap();
+        assert_eq!(output, Some(1));
+    }
+
+    #[test]
+    #[cfg(feature = "gvariant")]
+    fn deserialize_maybe_none() {
+        use crate::Maybe;
+        let input = Value::Maybe(Maybe::nothing(signature_string!("y")));
+        let de = input.into_deserializer();
+        let output: Option<u8> = Option::deserialize(de).unwrap();
+        assert_eq!(output, None);
+    }
+
+    #[test]
+    #[cfg(feature = "option-as-array")]
+    fn deserialize_array_some() {
+        let input = Value::Array(Array::from(vec![Value::U8(1)]));
+        let de = input.into_deserializer();
+        let output: Option<u8> = Option::deserialize(de).unwrap();
+        assert_eq!(output, Some(1));
+    }
+
+    #[test]
+    #[cfg(feature = "option-as-array")]
+    fn deserialize_array_none() {
+        let input = Value::Array(Array::new(signature_string!("y")));
+        let de = input.into_deserializer();
+        let output: Option<u8> = Option::deserialize(de).unwrap();
+        assert_eq!(output, None);
+    }
+}

--- a/zvariant/src/value/parsed_signature.rs
+++ b/zvariant/src/value/parsed_signature.rs
@@ -1,0 +1,646 @@
+//! A DBus/GVariant type signature parser and enum representation.
+//!
+//! This module provides a recursive-descent parser (based on `nom`)
+//! for DBus/GVariant type signatures. The parser returns an enum that
+//! represents the full type signature being reprsented by a given string
+//! or sequence of bytes.
+
+use std::collections::VecDeque;
+
+use nom::{
+    branch::alt, bytes::complete::tag, character::complete::anychar, combinator::all_consuming,
+    multi::many1, IResult,
+};
+
+use crate::{
+    Basic, Fd, ObjectPath, Signature, Type, ARRAY_SIGNATURE_STR, STRUCT_SIG_END_STR,
+    STRUCT_SIG_START_STR, VARIANT_SIGNATURE_CHAR, VARIANT_SIGNATURE_STR,
+};
+
+/// A parsed DBus/GVariant type signature.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ParsedSignature(VecDeque<SignatureEntry>);
+
+impl ParsedSignature {
+    /// Get the next entry in the signature to
+    /// be processed.
+    pub fn next(&mut self) -> Option<SignatureEntry> {
+        self.0.pop_front()
+    }
+
+    /// Check if the signature matches a given
+    /// type `T`.
+    pub fn matches<T: Type>(&self) -> bool {
+        T::signature() == signature_string!(&self.to_string())
+    }
+
+    /// Parse a byte slice into a `ParsedSignature`. If the entire
+    /// slice is not consumed by the parsing, an error is returned.
+    pub fn parse_bytes(input: &[u8]) -> crate::Result<ParsedSignature> {
+        match SignatureEntry::parse(input) {
+            Ok(entries) => Ok(ParsedSignature(entries)),
+            Err(err) => {
+                let reason = format!("Failed to parse signature. Reason: {:?}", err);
+                Err(crate::Error::Message(reason))
+            }
+        }
+    }
+
+    /// Parse a string slice into a `ParsedSignature`. If the entire
+    /// string is not consumed by the parsing, an error is returned.
+    pub fn parse_str(input: &str) -> crate::Result<ParsedSignature> {
+        Self::parse_bytes(input.as_bytes())
+    }
+}
+
+impl std::fmt::Display for ParsedSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for entry in &self.0 {
+            write!(f, "{}", entry)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> From<ParsedSignature> for Signature<'a> {
+    fn from(parsed: ParsedSignature) -> Self {
+        signature_string!(&parsed.to_string())
+    }
+}
+
+impl<'a> From<&ParsedSignature> for Signature<'a> {
+    fn from(parsed: &ParsedSignature) -> Self {
+        signature_string!(&parsed.to_string())
+    }
+}
+
+impl From<SignatureEntry> for ParsedSignature {
+    fn from(entry: SignatureEntry) -> Self {
+        ParsedSignature(vec![entry].into())
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum SignatureEntry {
+    U8,
+    U16,
+    U32,
+    U64,
+    I16,
+    I32,
+    I64,
+    F64,
+    Bool,
+    Str,
+    ObjectPath,
+    Signature,
+    Variant,
+    Array(Box<SignatureEntry>),
+    Struct(VecDeque<SignatureEntry>),
+    DictEntry(Box<SignatureEntry>, Box<SignatureEntry>),
+
+    #[cfg(unix)]
+    Fd,
+
+    #[cfg(feature = "gvariant")]
+    Maybe(Box<SignatureEntry>),
+}
+
+impl SignatureEntry {
+    pub fn matches<T: Type>(&self) -> bool {
+        T::signature() == signature_string!(&self.to_string())
+    }
+
+    pub fn parse(input: &[u8]) -> crate::Result<VecDeque<SignatureEntry>> {
+        match Self::parse_all(input) {
+            Ok((_, parsed)) => Ok(parsed),
+            Err(err) => {
+                let reason = format!("Failed to parse signature. Reason: {:?}", err);
+                Err(crate::Error::Message(reason))
+            }
+        }
+    }
+
+    fn basic(input: &[u8]) -> IResult<&[u8], SignatureEntry> {
+        let (input, next) = anychar(input)?;
+
+        match next {
+            u8::SIGNATURE_CHAR => Ok((input, SignatureEntry::U8)),
+            u16::SIGNATURE_CHAR => Ok((input, SignatureEntry::U16)),
+            u32::SIGNATURE_CHAR => Ok((input, SignatureEntry::U32)),
+            u64::SIGNATURE_CHAR => Ok((input, SignatureEntry::U64)),
+            i16::SIGNATURE_CHAR => Ok((input, SignatureEntry::I16)),
+            i32::SIGNATURE_CHAR => Ok((input, SignatureEntry::I32)),
+            i64::SIGNATURE_CHAR => Ok((input, SignatureEntry::I64)),
+            f64::SIGNATURE_CHAR => Ok((input, SignatureEntry::F64)),
+            bool::SIGNATURE_CHAR => Ok((input, SignatureEntry::Bool)),
+            String::SIGNATURE_CHAR => Ok((input, SignatureEntry::Str)),
+            ObjectPath::SIGNATURE_CHAR => Ok((input, SignatureEntry::ObjectPath)),
+            Signature::SIGNATURE_CHAR => Ok((input, SignatureEntry::Signature)),
+            VARIANT_SIGNATURE_CHAR => Ok((input, SignatureEntry::Variant)),
+
+            #[cfg(unix)]
+            Fd::SIGNATURE_CHAR => Ok((input, SignatureEntry::Fd)),
+
+            _ => Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::Char,
+            ))),
+        }
+    }
+
+    fn container_array(input: &[u8]) -> IResult<&[u8], SignatureEntry> {
+        let (input, _) = tag(ARRAY_SIGNATURE_STR)(input)?;
+        let (input, sig) = Self::array_element(input)?;
+        Ok((input, SignatureEntry::Array(Box::new(sig))))
+    }
+
+    fn container_struct(input: &[u8]) -> IResult<&[u8], SignatureEntry> {
+        let (input, _) = tag(STRUCT_SIG_START_STR)(input)?;
+        let (input, sigs) = Self::parse_many(input)?;
+        let (input, _) = tag(STRUCT_SIG_END_STR)(input)?;
+
+        Ok((input, SignatureEntry::Struct(sigs)))
+    }
+
+    fn container_dict_entry(input: &[u8]) -> IResult<&[u8], SignatureEntry> {
+        let (input, _) = tag("{")(input)?;
+        let (input, key) = Self::parse_one(input)?;
+        let (input, value) = Self::parse_one(input)?;
+        let (input, _) = tag("}")(input)?;
+
+        Ok((
+            input,
+            SignatureEntry::DictEntry(Box::new(key), Box::new(value)),
+        ))
+    }
+
+    fn array_element(input: &[u8]) -> IResult<&[u8], SignatureEntry> {
+        alt((
+            Self::basic,
+            Self::container_array,
+            Self::container_struct,
+            Self::container_dict_entry,
+            #[cfg(feature = "gvariant")]
+            Self::maybe,
+        ))(input)
+    }
+
+    #[cfg(feature = "gvariant")]
+    fn maybe(input: &[u8]) -> IResult<&[u8], SignatureEntry> {
+        let (input, _) = tag("m")(input)?;
+        let (input, sig) = Self::parse_one(input)?;
+
+        Ok((input, SignatureEntry::Maybe(Box::new(sig))))
+    }
+
+    fn parse_one(input: &[u8]) -> IResult<&[u8], SignatureEntry> {
+        alt((
+            Self::basic,
+            Self::container_array,
+            Self::container_struct,
+            #[cfg(feature = "gvariant")]
+            Self::maybe,
+        ))(input)
+    }
+
+    fn parse_many(input: &[u8]) -> IResult<&[u8], VecDeque<SignatureEntry>> {
+        let (input, entries) = many1(Self::parse_one)(input)?;
+        Ok((input, entries.into()))
+    }
+
+    fn parse_all(input: &[u8]) -> IResult<&[u8], VecDeque<SignatureEntry>> {
+        all_consuming(Self::parse_many)(input)
+    }
+}
+
+impl<'a> From<SignatureEntry> for Signature<'a> {
+    fn from(parsed: SignatureEntry) -> Self {
+        signature_string!(&parsed.to_string())
+    }
+}
+
+impl<'a> From<&SignatureEntry> for Signature<'a> {
+    fn from(parsed: &SignatureEntry) -> Self {
+        signature_string!(&parsed.to_string())
+    }
+}
+
+impl std::fmt::Display for SignatureEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SignatureEntry::U8 => f.write_str(u8::SIGNATURE_STR),
+            SignatureEntry::U16 => f.write_str(u16::SIGNATURE_STR),
+            SignatureEntry::U32 => f.write_str(u32::SIGNATURE_STR),
+            SignatureEntry::U64 => f.write_str(u64::SIGNATURE_STR),
+            SignatureEntry::I16 => f.write_str(i16::SIGNATURE_STR),
+            SignatureEntry::I32 => f.write_str(i32::SIGNATURE_STR),
+            SignatureEntry::I64 => f.write_str(i64::SIGNATURE_STR),
+            SignatureEntry::F64 => f.write_str(f64::SIGNATURE_STR),
+            SignatureEntry::Bool => f.write_str(bool::SIGNATURE_STR),
+            SignatureEntry::Str => f.write_str(String::SIGNATURE_STR),
+            SignatureEntry::ObjectPath => f.write_str(ObjectPath::SIGNATURE_STR),
+            SignatureEntry::Signature => f.write_str(Signature::SIGNATURE_STR),
+            SignatureEntry::Variant => f.write_str(VARIANT_SIGNATURE_STR),
+            SignatureEntry::Array(sig) => write!(f, "a{}", sig),
+            SignatureEntry::Struct(fields) => {
+                f.write_str("(")?;
+
+                for field in fields {
+                    write!(f, "{}", field)?;
+                }
+
+                f.write_str(")")
+            }
+            SignatureEntry::DictEntry(key, value) => write!(f, "{{{}{}}}", key, value),
+
+            #[cfg(unix)]
+            SignatureEntry::Fd => f.write_str(Fd::SIGNATURE_STR),
+
+            #[cfg(feature = "gvariant")]
+            SignatureEntry::Maybe(sig) => write!(f, "m{}", sig),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::Value;
+
+    use super::*;
+
+    #[test]
+    fn parse_signature_bool() {
+        let parsed = ParsedSignature::parse_str("b").unwrap();
+        assert_eq!(parsed, ParsedSignature(vec![SignatureEntry::Bool].into()));
+    }
+
+    #[test]
+    fn parse_signature_u8() {
+        let parsed = ParsedSignature::parse_str("y").unwrap();
+        assert_eq!(parsed, ParsedSignature(vec![SignatureEntry::U8].into()));
+    }
+
+    #[test]
+    fn parse_signature_u16() {
+        let parsed = ParsedSignature::parse_str("q").unwrap();
+        assert_eq!(parsed, ParsedSignature(vec![SignatureEntry::U16].into()));
+    }
+
+    #[test]
+    fn parse_signature_u32() {
+        let parsed = ParsedSignature::parse_str("u").unwrap();
+        assert_eq!(parsed, ParsedSignature(vec![SignatureEntry::U32].into()));
+    }
+
+    #[test]
+    fn parse_signature_u64() {
+        let parsed = ParsedSignature::parse_str("t").unwrap();
+        assert_eq!(parsed, ParsedSignature(vec![SignatureEntry::U64].into()));
+    }
+
+    #[test]
+    fn parse_signature_i16() {
+        let parsed = ParsedSignature::parse_str("n").unwrap();
+        assert_eq!(parsed, ParsedSignature(vec![SignatureEntry::I16].into()));
+    }
+
+    #[test]
+    fn parse_signature_i32() {
+        let parsed = ParsedSignature::parse_str("i").unwrap();
+        assert_eq!(parsed, ParsedSignature(vec![SignatureEntry::I32].into()));
+    }
+
+    #[test]
+    fn parse_signature_i64() {
+        let parsed = ParsedSignature::parse_str("x").unwrap();
+        assert_eq!(parsed, ParsedSignature(vec![SignatureEntry::I64].into()));
+    }
+
+    #[test]
+    fn parse_signature_double() {
+        let parsed = ParsedSignature::parse_str("d").unwrap();
+        assert_eq!(parsed, ParsedSignature(vec![SignatureEntry::F64].into()));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn parse_signature_fd() {
+        let parsed = ParsedSignature::parse_str("h").unwrap();
+        assert_eq!(parsed, ParsedSignature(vec![SignatureEntry::Fd].into()));
+    }
+
+    #[test]
+    fn parse_signature_string() {
+        let parsed = ParsedSignature::parse_str("s").unwrap();
+        assert_eq!(parsed, ParsedSignature(vec![SignatureEntry::Str].into()));
+    }
+
+    #[test]
+    fn parse_signature_object_path() {
+        let parsed = ParsedSignature::parse_str("o").unwrap();
+        assert_eq!(
+            parsed,
+            ParsedSignature(vec![SignatureEntry::ObjectPath].into())
+        );
+    }
+
+    #[test]
+    fn parse_signature_signature() {
+        let parsed = ParsedSignature::parse_str("g").unwrap();
+        assert_eq!(
+            parsed,
+            ParsedSignature(vec![SignatureEntry::Signature].into())
+        );
+    }
+
+    #[test]
+    fn parse_signature_variant() {
+        let parsed = ParsedSignature::parse_str("v").unwrap();
+        assert_eq!(
+            parsed,
+            ParsedSignature(vec![SignatureEntry::Variant].into())
+        );
+    }
+
+    #[test]
+    fn parse_signature_array() {
+        let parsed = ParsedSignature::parse_str("ai").unwrap();
+        assert_eq!(
+            parsed,
+            ParsedSignature(vec![SignatureEntry::Array(Box::new(SignatureEntry::I32))].into())
+        );
+    }
+
+    #[test]
+    fn parse_signature_struct() {
+        let parsed = ParsedSignature::parse_str("(iu)").unwrap();
+        assert_eq!(
+            parsed,
+            ParsedSignature(
+                vec![SignatureEntry::Struct(
+                    vec![SignatureEntry::I32, SignatureEntry::U32].into()
+                )]
+                .into()
+            )
+        );
+    }
+
+    #[test]
+    fn parse_nested_struct() {
+        let parsed = ParsedSignature::parse_str("(i(iu))").unwrap();
+        assert_eq!(
+            parsed,
+            ParsedSignature(
+                vec![SignatureEntry::Struct(
+                    vec![
+                        SignatureEntry::I32,
+                        SignatureEntry::Struct(
+                            vec![SignatureEntry::I32, SignatureEntry::U32].into()
+                        )
+                    ]
+                    .into()
+                )]
+                .into()
+            )
+        );
+    }
+
+    #[test]
+    fn parse_signature_dict() {
+        let parsed = ParsedSignature::parse_str("a{is}").unwrap();
+        assert_eq!(
+            parsed,
+            ParsedSignature(
+                vec![SignatureEntry::Array(Box::new(SignatureEntry::DictEntry(
+                    Box::new(SignatureEntry::I32),
+                    Box::new(SignatureEntry::Str)
+                )))]
+                .into()
+            )
+        );
+    }
+
+    #[test]
+    fn parse_nested_dict() {
+        let parsed = ParsedSignature::parse_str("a{ia{is}}").unwrap();
+        assert_eq!(
+            parsed,
+            ParsedSignature(
+                vec![SignatureEntry::Array(Box::new(SignatureEntry::DictEntry(
+                    Box::new(SignatureEntry::I32),
+                    Box::new(SignatureEntry::Array(Box::new(SignatureEntry::DictEntry(
+                        Box::new(SignatureEntry::I32),
+                        Box::new(SignatureEntry::Str)
+                    ))))
+                )))]
+                .into()
+            )
+        );
+    }
+
+    #[test]
+    fn parse_array_of_structs() {
+        let parsed = ParsedSignature::parse_str("a(iu)").unwrap();
+        assert_eq!(
+            parsed,
+            ParsedSignature(
+                vec![SignatureEntry::Array(Box::new(SignatureEntry::Struct(
+                    vec![SignatureEntry::I32, SignatureEntry::U32].into()
+                )))]
+                .into()
+            )
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "gvariant")]
+    fn parse_maybe() {
+        let parsed = ParsedSignature::parse_str("ms").unwrap();
+        assert_eq!(
+            parsed,
+            ParsedSignature(vec![SignatureEntry::Maybe(Box::new(SignatureEntry::Str))].into())
+        );
+    }
+
+    #[test]
+    fn fails_parse_lone_dictentry() {
+        assert!(ParsedSignature::parse_str("{is}").is_err());
+    }
+
+    #[test]
+    fn fails_parse_unclosed_dict() {
+        assert!(ParsedSignature::parse_str("a{is").is_err());
+    }
+
+    #[test]
+    fn fails_parse_unopened_dict() {
+        assert!(ParsedSignature::parse_str("ais}").is_err());
+    }
+
+    #[test]
+    fn fails_parse_unopened_struct() {
+        assert!(ParsedSignature::parse_str("is)").is_err());
+    }
+
+    #[test]
+    fn fails_parse_invalid_char() {
+        assert!(ParsedSignature::parse_str("p").is_err());
+    }
+
+    #[test]
+    fn next() {
+        let mut parsed = ParsedSignature::parse_str("ius").unwrap();
+        assert_eq!(parsed.next(), Some(SignatureEntry::I32));
+        assert_eq!(parsed.next(), Some(SignatureEntry::U32));
+        assert_eq!(parsed.next(), Some(SignatureEntry::Str));
+        assert_eq!(parsed.next(), None);
+    }
+
+    #[test]
+    fn matches_bool() {
+        let parsed = ParsedSignature::parse_str("b").unwrap();
+        assert!(parsed.matches::<bool>());
+        assert!(!parsed.matches::<u8>());
+    }
+
+    #[test]
+    fn matches_u8() {
+        let parsed = ParsedSignature::parse_str("y").unwrap();
+        assert!(parsed.matches::<u8>());
+        assert!(!parsed.matches::<u16>());
+    }
+
+    #[test]
+    fn matches_u16() {
+        let parsed = ParsedSignature::parse_str("q").unwrap();
+        assert!(parsed.matches::<u16>());
+        assert!(!parsed.matches::<u8>());
+    }
+
+    #[test]
+    fn matches_u32() {
+        let parsed = ParsedSignature::parse_str("u").unwrap();
+        assert!(parsed.matches::<u32>());
+        assert!(!parsed.matches::<u16>());
+    }
+
+    #[test]
+    fn matches_u64() {
+        let parsed = ParsedSignature::parse_str("t").unwrap();
+        assert!(parsed.matches::<u64>());
+        assert!(!parsed.matches::<u32>());
+    }
+
+    #[test]
+    fn matches_i16() {
+        let parsed = ParsedSignature::parse_str("n").unwrap();
+        assert!(parsed.matches::<i16>());
+        assert!(!parsed.matches::<u16>());
+    }
+
+    #[test]
+    fn matches_i32() {
+        let parsed = ParsedSignature::parse_str("i").unwrap();
+        assert!(parsed.matches::<i32>());
+        assert!(!parsed.matches::<u32>());
+    }
+
+    #[test]
+    fn matches_i64() {
+        let parsed = ParsedSignature::parse_str("x").unwrap();
+        assert!(parsed.matches::<i64>());
+        assert!(!parsed.matches::<u64>());
+    }
+
+    #[test]
+    fn matches_double() {
+        let parsed = ParsedSignature::parse_str("d").unwrap();
+        assert!(parsed.matches::<f64>());
+        assert!(!parsed.matches::<i64>());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn matches_fd() {
+        let parsed = ParsedSignature::parse_str("h").unwrap();
+        assert!(parsed.matches::<Fd<'_>>());
+        assert!(!parsed.matches::<f64>());
+    }
+
+    #[test]
+    fn matches_string() {
+        let parsed = ParsedSignature::parse_str("s").unwrap();
+        assert!(parsed.matches::<String>());
+        assert!(parsed.matches::<&str>());
+        assert!(parsed.matches::<&'static str>());
+        assert!(!parsed.matches::<f64>());
+    }
+
+    #[test]
+    fn matches_object_path() {
+        let parsed = ParsedSignature::parse_str("o").unwrap();
+        assert!(parsed.matches::<ObjectPath<'_>>());
+        assert!(!parsed.matches::<f64>());
+    }
+
+    #[test]
+    fn matches_signature() {
+        let parsed = ParsedSignature::parse_str("g").unwrap();
+        assert!(parsed.matches::<Signature<'_>>());
+        assert!(!parsed.matches::<f64>());
+    }
+
+    #[test]
+    fn matches_variant() {
+        let parsed = ParsedSignature::parse_str("v").unwrap();
+        assert!(parsed.matches::<Value<'_>>());
+        assert!(!parsed.matches::<f64>());
+    }
+
+    #[test]
+    fn matches_array() {
+        let parsed = ParsedSignature::parse_str("ai").unwrap();
+        assert!(parsed.matches::<Vec<i32>>());
+        assert!(!parsed.matches::<Vec<u8>>());
+        assert!(!parsed.matches::<f64>());
+    }
+
+    #[test]
+    fn matches_struct() {
+        let parsed = ParsedSignature::parse_str("(iu)").unwrap();
+        assert!(parsed.matches::<(i32, u32)>());
+        assert!(!parsed.matches::<(u32, i32)>());
+        assert!(!parsed.matches::<f64>());
+    }
+
+    #[test]
+    fn matches_dict() {
+        let parsed = ParsedSignature::parse_str("a{is}").unwrap();
+        assert!(parsed.matches::<std::collections::HashMap<i32, String>>());
+        assert!(!parsed.matches::<std::collections::HashMap<u32, String>>());
+        assert!(!parsed.matches::<f64>());
+    }
+
+    #[test]
+    #[cfg(all(feature = "gvariant", not(feature = "option-as_array")))]
+    fn matches_maybe() {
+        let parsed = ParsedSignature::parse_str("ms").unwrap();
+        assert_eq!(Option::<String>::signature().as_str(), "ms");
+        assert!(parsed.matches::<Option<String>>());
+        assert!(!parsed.matches::<Option<u8>>());
+        assert!(!parsed.matches::<String>());
+        assert!(!parsed.matches::<f64>());
+    }
+
+    #[test]
+    #[cfg(all(feature = "option-as-array", not(feature = "gvariant")))]
+    fn matches_maybe() {
+        let parsed = ParsedSignature::parse_str("as").unwrap();
+        assert!(parsed.matches::<Option<String>>());
+        assert!(!parsed.matches::<Option<u8>>());
+        assert!(!parsed.matches::<String>());
+        assert!(!parsed.matches::<f64>());
+    }
+}

--- a/zvariant/src/value/parsed_signature.rs
+++ b/zvariant/src/value/parsed_signature.rs
@@ -227,6 +227,12 @@ impl<'a> From<&SignatureEntry> for Signature<'a> {
     }
 }
 
+impl<'a> From<&mut SignatureEntry> for Signature<'a> {
+    fn from(parsed: &mut SignatureEntry) -> Self {
+        signature_string!(&parsed.to_string())
+    }
+}
+
 impl std::fmt::Display for SignatureEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/zvariant/src/value/ser.rs
+++ b/zvariant/src/value/ser.rs
@@ -1,0 +1,1175 @@
+//! Serialization of Rust types into `Value` variants.
+//!
+//! This module provides a `Serializer` implementation that may be
+//! used to serialize Rust types into `Value` variants. These types
+//! should be serializable into a specific signature provided at
+//! construction time.
+//!
+//! Normally this module is not used directly, but is instead
+//! invoked via the `zvariant::to_value` methods provided by
+//! this crate.
+
+use std::{collections::VecDeque, marker::PhantomData};
+
+#[cfg(feature = "gvariant")]
+use crate::Maybe;
+use crate::{
+    basic::Basic, value::parsed_signature::{ParsedSignature, SignatureEntry}, Array, Dict, ObjectPath, Signature, Str, StructureBuilder, Value
+};
+use serde::{
+    de::Error,
+    ser::{
+        SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
+        SerializeTupleStruct, SerializeTupleVariant,
+    },
+    Serializer,
+};
+
+/// Serialize a basic type into a `Value` variant. This macro can
+/// be used to serialize any basic type that requires no or minimal
+/// conversion (using `as`) to encode it as a `Value` variant.
+macro_rules! serialize_basic_type {
+    ($func:ident($type:ty), $enum:expr) => {
+        #[inline]
+        fn $func(mut self, value: $type) -> Result<Self::Ok, crate::Error> {
+            match self.signature.next() {
+                Some(signature) => {
+                    if signature.matches::<$type>() {
+                        return Ok($enum(value));
+                    } else {
+                        Err(crate::Error::SignatureMismatch(
+                            signature.into(),
+                            <$type as Basic>::SIGNATURE_STR.to_string(),
+                        ))
+                    }
+                }
+                None => Err(crate::Error::UnexpectedValue(value.to_string()))
+            }
+        }
+    };
+
+    ($func:ident($type:ty), $enum:expr, $as:ty) => {
+        #[inline]
+        fn $func(mut self, value: $type) -> Result<Self::Ok, crate::Error> {
+            match self.signature.next() {
+                Some(signature) => {
+                    if signature.matches::<$type>() {
+                        return Ok($enum(value as $as));
+                    } else {
+                        Err(crate::Error::SignatureMismatch(
+                            signature.into(),
+                            <$type as Basic>::SIGNATURE_STR.to_string(),
+                        ))
+                    }
+                }
+                
+                None => Err(crate::Error::UnexpectedValue(value.to_string()))
+            }
+        }
+    };
+}
+
+/// A serializer implementation which produces a `Value` variant
+/// from the given input. It serializes according to a signature
+/// provided at construction time. If the given input does not
+/// compatible the given signature errors will be produced.
+pub struct ValueSerializer<'a> {
+    signature: ParsedSignature,
+    phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> ValueSerializer<'a> {
+    pub fn new(signature: Signature<'_>) -> Self {
+        Self {
+            signature: ParsedSignature::parse_bytes(signature.as_bytes()).unwrap(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a> Serializer for ValueSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+    type SerializeSeq = ValueSeqSerializer<'a>;
+    type SerializeTuple = ValueTupleSerializer<'a>;
+    type SerializeTupleStruct = ValueTupleStructSerializer<'a>;
+    type SerializeTupleVariant = ValueTupleVariantSerializer<'a>;
+    type SerializeMap = ValueMapSerializer<'a>;
+    type SerializeStruct = ValueStructSerializer<'a>;
+    type SerializeStructVariant = ValueStructVariantSerializer<'a>;
+
+    serialize_basic_type!(serialize_bool(bool), Value::Bool);
+    serialize_basic_type!(serialize_i8(i8), Value::I16, i16);
+    serialize_basic_type!(serialize_i16(i16), Value::I16);
+    serialize_basic_type!(serialize_i32(i32), Value::I32);
+    serialize_basic_type!(serialize_i64(i64), Value::I64);
+    serialize_basic_type!(serialize_u8(u8), Value::U8);
+    serialize_basic_type!(serialize_u16(u16), Value::U16);
+    serialize_basic_type!(serialize_u32(u32), Value::U32);
+    serialize_basic_type!(serialize_u64(u64), Value::U64);
+    serialize_basic_type!(serialize_f32(f32), Value::F64, f64);
+    serialize_basic_type!(serialize_f64(f64), Value::F64);
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        self.serialize_str(&v.to_string())
+    }
+
+    fn serialize_str(mut self, v: &str) -> Result<Self::Ok, Self::Error> {
+        match self.signature.next() {
+            Some(SignatureEntry::ObjectPath) => {
+                Ok(Value::ObjectPath(ObjectPath::try_from(v.to_string())?))
+            }
+            Some(SignatureEntry::Signature) => {
+                Ok(Value::Signature(Signature::try_from(v.to_string())?))
+            }
+            Some(SignatureEntry::Str) => Ok(Value::Str(Str::from(v.to_string()))),
+            Some(signature) => Err(crate::Error::SignatureMismatch(
+                signature.into(),
+                String::SIGNATURE_STR.to_string(),
+            )),
+            None => Err(crate::Error::UnexpectedValue(v.to_string()))
+        }
+    }
+
+    fn serialize_bytes(mut self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        match self.signature.next() {
+            Some(SignatureEntry::Array(elem_signature)) => match *elem_signature {
+                SignatureEntry::U8 => Ok(Value::Array(Array::from(v.to_vec()))),
+                signature => Err(crate::Error::SignatureMismatch(
+                    signature.into(),
+                    "ay".to_string(),
+                )),
+            },
+            Some(signature) => Err(crate::Error::SignatureMismatch(
+                signature.into(),
+                "ay".to_string(),
+            )),
+            None => Err(crate::Error::UnexpectedValue("No signature provided for serialized bytes".to_string()))
+        }
+    }
+
+    fn serialize_none(mut self) -> Result<Self::Ok, Self::Error> {
+        match self.signature.next() {
+            #[cfg(feature = "gvariant")]
+            Some(SignatureEntry::Maybe(signature)) => {
+                let signature = *signature;
+                Ok(Value::Maybe(Maybe::nothing_full_signature(
+                    signature.into(),
+                )))
+            }
+
+            #[cfg(feature = "option-as-array")]
+            Some(SignatureEntry::Array(signature)) => {
+                let signature = *signature;
+                Ok(Value::Array(Array::new(signature.into())))
+            }
+
+            _ => unreachable!(
+                "Can only encode Option<T> if `option-as-array` or `gvariant` feature is enabled",
+            ),
+        }
+    }
+
+    fn serialize_some<T>(mut self, #[allow(unused)] value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        match self.signature.next() {
+            #[cfg(feature = "gvariant")]
+            Some(SignatureEntry::Maybe(signature)) => {
+                let signature = *signature;
+                let value: Value<'a> =
+                    value.serialize(ValueSerializer::new(signature.clone().into()))?;
+                Ok(Value::Maybe(Maybe::just_full_signature(
+                    value,
+                    signature.into(),
+                )))
+            }
+
+            #[cfg(feature = "option-as-array")]
+            Some(SignatureEntry::Array(signature)) => {
+                let signature = *signature;
+                let mut array = Array::new(signature.clone().into());
+                let value: Value<'a> = value.serialize(ValueSerializer::new(signature.into()))?;
+                array.append(value)?;
+                Ok(Value::Array(array))
+            }
+
+            _ => unreachable!("Can only encode Option<T> if `option-as-array` feature is enabled"),
+        }
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        unimplemented!("serializing unit")
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        self.serialize_unit()
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        let structure = StructureBuilder::new().add_field(variant).build();
+
+        Ok(Value::Structure(structure))
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        match name {
+            "zvariant::ObjectPath" => match value.serialize(self)? {
+                Value::Str(s) => Ok(Value::ObjectPath(ObjectPath::try_from(s.to_string())?)),
+                Value::ObjectPath(p) => Ok(Value::ObjectPath(p)),
+                value => Err(crate::Error::invalid_type(
+                    value.unexpected(),
+                    &"an object path",
+                )),
+            },
+            "zvariant::Signature" => match value.serialize(self)? {
+                Value::Str(s) => Ok(Value::Signature(Signature::try_from(s.to_string())?)),
+                Value::Signature(s) => Ok(Value::Signature(s)),
+                value => Err(crate::Error::invalid_type(
+                    value.unexpected(),
+                    &"a signature",
+                )),
+            },
+            _ => {
+                let structure = StructureBuilder::new()
+                    .append_field(value.serialize(self)?)
+                    .build();
+
+                Ok(Value::Structure(structure))
+            }
+        }
+    }
+
+    fn serialize_newtype_variant<T>(
+        mut self,
+        _name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        match self.signature.next().as_mut() {
+            Some(SignatureEntry::Struct(fields)) => {
+                let discriminator = match fields.pop_front() {
+                    Some(SignatureEntry::Str) => Value::Str(Str::from(variant)),
+                    Some(SignatureEntry::U32) => Value::U32(variant_index),
+                    Some(signature) => {
+                        return Err(crate::Error::SignatureMismatch(
+                            signature.into(),
+                            "a valid newtype variant discriminant signature".to_string(),
+                        ));
+                    }
+                    None => {
+                        return Err(crate::Error::Message(
+                            "Newtype variant discriminant required".to_string(),
+                        ));
+                    }
+                };
+
+                if let Some(data_field) = fields.pop_front() {
+                    let structure = StructureBuilder::new()
+                        .append_field(discriminator)
+                        .append_field(value.serialize(ValueSerializer::new(data_field.into()))?)
+                        .build();
+
+                    Ok(Value::Structure(structure))
+                } else {
+                    Err(crate::Error::Message("Struct field required".to_string()))
+                }
+            }
+            Some(signature) => Err(crate::Error::SignatureMismatch(
+                signature.into(),
+                "a valid newtype variant signature".to_string(),
+            )),
+            None => Err(crate::Error::UnexpectedValue(
+                "No signature found for serialized newtype variant".to_string()
+            ))
+        }
+    }
+
+    fn serialize_seq(mut self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        match self.signature.next() {
+            Some(SignatureEntry::Array(signature)) => Ok(ValueSeqSerializer::new(*signature)),
+            Some(signature) => Err(crate::Error::SignatureMismatch(
+                signature.into(),
+                "an array".to_string(),
+            )),
+            None => Err(crate::Error::UnexpectedValue(
+                "No signature found for serialized sequence".to_string()
+            ))
+        }
+    }
+
+    fn serialize_tuple(mut self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        match self.signature.next() {
+            Some(SignatureEntry::Struct(signature)) => Ok(ValueTupleSerializer::new(signature)),
+            Some(signature) => Err(crate::Error::SignatureMismatch(
+                signature.into(),
+                "a valid tuple signature".to_string(),
+            )),
+            None => Err(crate::Error::UnexpectedValue(
+                "No signature found for serialized tuple".to_string()
+            ))
+        }
+    }
+
+    fn serialize_tuple_struct(
+        mut self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        match self.signature.next() {
+            Some(SignatureEntry::Struct(signature)) => {
+                Ok(ValueTupleStructSerializer::new(name.to_string(), signature))
+            }
+            Some(signature) => Err(crate::Error::SignatureMismatch(
+                signature.into(),
+                "a valid tuple-struct signature".to_string(),
+            )),
+            None => Err(crate::Error::UnexpectedValue(
+                "No signature found for serialized tuple-struct".to_string()
+            ))
+        }
+    }
+
+    fn serialize_tuple_variant(
+        mut self,
+        _name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        match self.signature.next() {
+            Some(SignatureEntry::Struct(mut signature)) => {
+                let discriminant = match signature.pop_front() {
+                    Some(SignatureEntry::U32) => Value::U32(variant_index),
+                    Some(SignatureEntry::Str) => Value::Str(Str::from(variant)),
+                    Some(signature) => {
+                        return Err(crate::Error::SignatureMismatch(
+                            signature.into(),
+                            "a valid tuple-variant discriminant signature".to_string(),
+                        ));
+                    }
+                    None => {
+                        return Err(crate::Error::UnexpectedValue(
+                            "Tuple variant discriminant required".to_string(),
+                        ));
+                    }
+                };
+
+                match signature.pop_front() {
+                    Some(SignatureEntry::Struct(signature)) => {
+                        Ok(ValueTupleVariantSerializer::new(discriminant, signature))
+                    }
+                    Some(signature) => Err(crate::Error::SignatureMismatch(
+                        signature.into(),
+                        "a valid tuple-variant inner value signature".to_string(),
+                    )),
+                    None => Err(crate::Error::UnexpectedValue(
+                        "No signature found for serialized tuple-variant inner content".to_string()
+                    ))
+                }
+            }
+            Some(signature) => Err(crate::Error::SignatureMismatch(
+                signature.into(),
+                "a valid tuple-struct signature".to_string(),
+            )),
+
+            None => Err(crate::Error::UnexpectedValue(
+                "No signature found for serialized tuple-variant".to_string()
+            ))
+        }
+    }
+
+    fn serialize_map(mut self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        match self.signature.next() {
+            Some(SignatureEntry::Array(inner_sig)) => match *inner_sig {
+                SignatureEntry::DictEntry(key, value) => Ok(ValueMapSerializer::new(*key, *value)),
+                _ => Err(crate::Error::SignatureMismatch(
+                    (*inner_sig).into(),
+                    "a DictEntry".to_string(),
+                )),
+            },
+            Some(signature) => Err(crate::Error::SignatureMismatch(
+                signature.into(),
+                "a Dictionary of the form a{kv}".to_string(),
+            )),
+            None => Err(crate::Error::UnexpectedValue(
+                "No signature found for serialized map".to_string()
+            ))
+        }
+    }
+
+    fn serialize_struct(
+        mut self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        match self.signature.next() {
+            Some(SignatureEntry::Struct(signature)) => Ok(ValueStructSerializer::new(signature)),
+
+            Some(signature) => Err(crate::Error::SignatureMismatch(
+                signature.into(),
+                "a valid struct signature".to_string(),
+            )),
+
+            None => Err(crate::Error::UnexpectedValue(
+                "No signature found for serialized struct".to_string()
+            ))
+        }
+    }
+
+    fn serialize_struct_variant(
+        mut self,
+        _name: &'static str,
+        variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        match self.signature.next() {
+            Some(SignatureEntry::Struct(mut signature)) => {
+                let discriminant = match signature.pop_front() {
+                    Some(SignatureEntry::U32) => Value::U32(variant_index),
+                    Some(SignatureEntry::Str) => Value::Str(Str::from(variant)),
+                    Some(signature) => {
+                        return Err(crate::Error::SignatureMismatch(
+                            signature.into(),
+                            "a valid struct-variant discriminant signature".to_string(),
+                        ));
+                    }
+                    None => {
+                        return Err(crate::Error::UnexpectedValue(
+                            "Struct variant discriminant required".to_string(),
+                        ));
+                    }
+                };
+
+                match signature.pop_front() {
+                    Some(SignatureEntry::Struct(signature)) => {
+                        Ok(ValueStructVariantSerializer::new(discriminant, signature))
+                    }
+
+                    Some(signature) => Err(crate::Error::SignatureMismatch(
+                        signature.into(),
+                        "a valid struct-variant signature".to_string(),
+                    )),
+
+                    None => Err(crate::Error::UnexpectedValue(
+                        "No signature found for serialized struct-variant inner content".to_string()
+                    ))
+                }
+            }
+
+            Some(signature) => Err(crate::Error::SignatureMismatch(
+                signature.into(),
+                "a valid struct-variant signature".to_string(),
+            )),
+
+            None => Err(crate::Error::UnexpectedValue(
+                "No signature found for serialized struct-variant".to_string()
+            ))
+        }
+    }
+}
+
+/// Serialize a sequence of items matching the given signature
+/// into an `Array`.
+pub struct ValueSeqSerializer<'a> {
+    signature: SignatureEntry,
+    fields: Vec<Value<'a>>,
+}
+
+impl<'a> ValueSeqSerializer<'a> {
+    pub fn new(signature: SignatureEntry) -> Self {
+        Self {
+            signature,
+            fields: Vec::new(),
+        }
+    }
+}
+
+impl<'a> SerializeSeq for ValueSeqSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        self.fields
+            .push(value.serialize(ValueSerializer::new(self.signature.clone().into()))?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Value::Array(Array::from(self.fields)))
+    }
+}
+
+/// Serialize a tuple of items matching the given signature
+/// sequence into a `Structure`.
+pub struct ValueTupleSerializer<'a> {
+    signature_entries: VecDeque<SignatureEntry>,
+    fields: Vec<Value<'a>>,
+}
+
+impl<'a> ValueTupleSerializer<'a> {
+    pub fn new(signature_entries: VecDeque<SignatureEntry>) -> Self {
+        Self {
+            signature_entries,
+            fields: Vec::new(),
+        }
+    }
+}
+
+impl<'a> SerializeTuple for ValueTupleSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        if let Some(signature) = self.signature_entries.pop_front() {
+            let serializer = ValueSerializer::new(signature.into());
+            self.fields.push(value.serialize(serializer)?);
+            Ok(())
+        } else {
+            Err(crate::Error::Message(
+                "Too many elements for the tuple".to_string(),
+            ))
+        }
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        let mut builder = StructureBuilder::new();
+
+        for field in self.fields.drain(..) {
+            builder.push_value(field);
+        }
+
+        Ok(Value::Structure(builder.build()))
+    }
+}
+
+/// Serialize a "Tuple Struct" (of the form `struct Name(u32, String)`)
+/// into a `Structure`.
+pub struct ValueTupleStructSerializer<'a> {
+    signature_entries: VecDeque<SignatureEntry>,
+    fields: Vec<Value<'a>>,
+}
+
+impl<'a> ValueTupleStructSerializer<'a> {
+    pub fn new(_name: String, signature_entries: VecDeque<SignatureEntry>) -> Self {
+        Self {
+            signature_entries,
+            fields: vec![],
+        }
+    }
+}
+
+impl<'a> SerializeTupleStruct for ValueTupleStructSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        if let Some(signature) = self.signature_entries.pop_front() {
+            let serializer = ValueSerializer::new(signature.into());
+            self.fields.push(value.serialize(serializer)?);
+            Ok(())
+        } else {
+            Err(crate::Error::Message(
+                "Too many elements for the tuple".to_string(),
+            ))
+        }
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        let mut builder = StructureBuilder::new();
+
+        for field in self.fields.drain(..) {
+            builder.push_value(field);
+        }
+
+        Ok(Value::Structure(builder.build()))
+    }
+}
+
+/// Serialize a tuple variant (of the form `enum MyEnum { A(u32, String) }`)
+/// into a `Structure` with the discriminant as the first field.
+pub struct ValueTupleVariantSerializer<'a> {
+    signature_entries: VecDeque<SignatureEntry>,
+    fields: Vec<Value<'a>>,
+}
+
+impl<'a> ValueTupleVariantSerializer<'a> {
+    pub fn new(discriminant: Value<'a>, signature_entries: VecDeque<SignatureEntry>) -> Self {
+        Self {
+            signature_entries,
+            fields: vec![discriminant],
+        }
+    }
+}
+
+impl<'a> SerializeTupleVariant for ValueTupleVariantSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        if let Some(signature) = self.signature_entries.pop_front() {
+            let serializer = ValueSerializer::new(signature.into());
+            self.fields.push(value.serialize(serializer)?);
+            Ok(())
+        } else {
+            Err(crate::Error::Message(
+                "Too many elements for the tuple".to_string(),
+            ))
+        }
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        let mut builder = StructureBuilder::new();
+
+        for field in self.fields.drain(..) {
+            builder.push_value(field);
+        }
+
+        Ok(Value::Structure(builder.build()))
+    }
+}
+
+/// Serialize a map of items matching the given key and
+/// value signatures into a `Dict`.
+pub struct ValueMapSerializer<'a> {
+    key_signature: SignatureEntry,
+    value_signature: SignatureEntry,
+    keys: Vec<Value<'a>>,
+    values: Vec<Value<'a>>,
+}
+
+impl<'a> ValueMapSerializer<'a> {
+    pub fn new(key_signature: SignatureEntry, value_signature: SignatureEntry) -> Self {
+        Self {
+            key_signature,
+            value_signature,
+            keys: Vec::new(),
+            values: Vec::new(),
+        }
+    }
+}
+
+impl<'a> SerializeMap for ValueMapSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        self.keys
+            .push(key.serialize(ValueSerializer::new(self.key_signature.clone().into()))?);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        self.values
+            .push(value.serialize(ValueSerializer::new(self.value_signature.clone().into()))?);
+        Ok(())
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        let mut dict = Dict::new(self.key_signature.into(), self.value_signature.into());
+
+        for (k, v) in self.keys.drain(..).zip(self.values.drain(..)) {
+            dict.append(k, v)?;
+        }
+
+        Ok(Value::Dict(dict))
+    }
+}
+
+/// Serialize a struct (of the form `struct MyStruct { a: u32, b: String }`)
+/// into a `Structure`.
+pub struct ValueStructSerializer<'a> {
+    signature_entries: VecDeque<SignatureEntry>,
+    values: Vec<Value<'a>>,
+}
+
+impl<'a> ValueStructSerializer<'a> {
+    pub fn new(signature_entries: VecDeque<SignatureEntry>) -> Self {
+        Self {
+            signature_entries,
+            values: Vec::new(),
+        }
+    }
+}
+
+impl<'a> SerializeStruct for ValueStructSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        if let Some(signature) = self.signature_entries.pop_front() {
+            let serializer = ValueSerializer::new(signature.into());
+            self.values.push(value.serialize(serializer)?);
+            Ok(())
+        } else {
+            Err(crate::Error::Message(
+                "Too many elements for the struct".to_string(),
+            ))
+        }
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        let mut builder = StructureBuilder::new();
+
+        for field in self.values.drain(..) {
+            builder.push_value(field);
+        }
+
+        Ok(Value::Structure(builder.build()))
+    }
+}
+
+/// Serialize a struct variant (of the form `enum MyEnum { A { a: u32, b: String } }`)
+/// into a `Structure` with the discriminant as the first field.
+pub struct ValueStructVariantSerializer<'a> {
+    fields: Vec<Value<'a>>,
+    signature_entries: VecDeque<SignatureEntry>,
+}
+
+impl<'a> ValueStructVariantSerializer<'a> {
+    pub fn new(discriminant: Value<'a>, signature_entries: VecDeque<SignatureEntry>) -> Self {
+        Self {
+            fields: vec![discriminant],
+            signature_entries,
+        }
+    }
+}
+
+impl<'a> SerializeStructVariant for ValueStructVariantSerializer<'a> {
+    type Ok = Value<'a>;
+    type Error = crate::Error;
+
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + serde::Serialize,
+    {
+        if let Some(signature) = self.signature_entries.pop_front() {
+            let serializer = ValueSerializer::new(signature.into());
+            self.fields.push(value.serialize(serializer)?);
+            Ok(())
+        } else {
+            Err(crate::Error::Message(
+                "Too many elements for the struct".to_string(),
+            ))
+        }
+    }
+
+    fn end(mut self) -> Result<Self::Ok, Self::Error> {
+        let mut builder = StructureBuilder::new();
+
+        for field in self.fields.drain(..) {
+            builder.push_value(field);
+        }
+
+        Ok(Value::Structure(builder.build()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{ObjectPath, OwnedObjectPath, OwnedSignature, Type};
+    use serde::Serialize;
+
+    #[test]
+    fn serialize_u8() {
+        let input = 42u8;
+        let output = input
+            .serialize(ValueSerializer::new(u8::signature()))
+            .unwrap();
+        assert_eq!(output, Value::U8(42));
+    }
+
+    #[test]
+    fn serialize_u8_bad_signature() {
+        let input = 42u8;
+        let err = input
+            .serialize(ValueSerializer::new(u16::signature()))
+            .expect_err("Should fail due to signature mismatch");
+        assert_eq!(err.to_string(), "Signature mismatch: got `q`, expected y");
+    }
+
+    #[test]
+    fn serialize_u16() {
+        let input = 42u16;
+        let output = input
+            .serialize(ValueSerializer::new(u16::signature()))
+            .unwrap();
+        assert_eq!(output, Value::U16(42));
+    }
+
+    #[test]
+    fn serialize_u32() {
+        let input = 42u32;
+        let output = input
+            .serialize(ValueSerializer::new(u32::signature()))
+            .unwrap();
+        assert_eq!(output, Value::U32(42));
+    }
+
+    #[test]
+    fn serialize_u64() {
+        let input = 42u64;
+        let output = input
+            .serialize(ValueSerializer::new(u64::signature()))
+            .unwrap();
+        assert_eq!(output, Value::U64(42));
+    }
+
+    #[test]
+    fn serialize_i8() {
+        let input = 42i8;
+        let output = input
+            .serialize(ValueSerializer::new(i16::signature()))
+            .unwrap();
+        assert_eq!(output, Value::I16(42));
+    }
+
+    #[test]
+    fn serialize_i16() {
+        let input = 42i16;
+        let output = input
+            .serialize(ValueSerializer::new(i16::signature()))
+            .unwrap();
+        assert_eq!(output, Value::I16(42));
+    }
+
+    #[test]
+    fn serialize_i32() {
+        let input = 42i32;
+        let output = input
+            .serialize(ValueSerializer::new(signature_string!("i")))
+            .unwrap();
+        assert_eq!(output, Value::I32(42));
+    }
+
+    #[test]
+    fn serialize_i64() {
+        let input = 42i64;
+        let output = input
+            .serialize(ValueSerializer::new(signature_string!("x")))
+            .unwrap();
+        assert_eq!(output, Value::I64(42));
+    }
+
+    #[test]
+    fn serialize_f32() {
+        let input = 42.0f32;
+        let output = input
+            .serialize(ValueSerializer::new(signature_string!("d")))
+            .unwrap();
+        assert_eq!(output, Value::F64(42.0));
+    }
+
+    #[test]
+    fn serialize_f64() {
+        let input = 42.0f64;
+        let output = input
+            .serialize(ValueSerializer::new(signature_string!("d")))
+            .unwrap();
+        assert_eq!(output, Value::F64(42.0));
+    }
+
+    #[test]
+    fn serialize_bool() {
+        let input = true;
+        let output = input
+            .serialize(ValueSerializer::new(signature_string!("b")))
+            .unwrap();
+        assert_eq!(output, Value::Bool(true));
+    }
+
+    #[test]
+    fn serialize_char() {
+        let input: char = 'a';
+        let output = input
+            .serialize(ValueSerializer::new(char::signature()))
+            .unwrap();
+        assert_eq!(output, Value::Str(Str::from("a")));
+    }
+
+    #[test]
+    fn serialize_string() {
+        let input: String = "Hello World".to_string();
+        let output = input
+            .serialize(ValueSerializer::new(signature_string!("s")))
+            .unwrap();
+        assert_eq!(output, Value::Str(Str::from("Hello World")));
+    }
+
+    #[test]
+    fn serialize_string_as_path() {
+        let input: String = "/hello".to_string();
+        let output = input
+            .serialize(ValueSerializer::new(signature_string!("o")))
+            .unwrap();
+        assert_eq!(
+            output,
+            Value::ObjectPath(ObjectPath::try_from("/hello").unwrap())
+        );
+    }
+
+    #[test]
+    fn serialize_string_as_signature() {
+        let input: String = "a{sv}".to_string();
+        let output = input
+            .serialize(ValueSerializer::new(Signature::signature()))
+            .unwrap();
+        assert_eq!(output, Value::Signature(signature_string!("a{sv}")));
+    }
+
+    #[test]
+    fn serialize_newtype_struct() {
+        #[derive(Serialize, Type)]
+        struct NewTypeStruct(i32);
+
+        let input: NewTypeStruct = NewTypeStruct(42);
+        let output = input
+            .serialize(ValueSerializer::new(NewTypeStruct::signature()))
+            .unwrap();
+
+        let expected = StructureBuilder::new().add_field(42i32).build();
+        assert_eq!(output, Value::Structure(expected));
+    }
+
+    #[test]
+    fn serialize_object_path() {
+        let input = ObjectPath::try_from("/hello").unwrap();
+        let output = input
+            .serialize(ValueSerializer::new(ObjectPath::signature()))
+            .unwrap();
+        assert_eq!(
+            output,
+            Value::ObjectPath(ObjectPath::try_from("/hello").unwrap())
+        );
+    }
+
+    #[test]
+    fn serialize_signature() {
+        let input = signature_string!("a(sv)");
+        let output = input
+            .serialize(ValueSerializer::new(Signature::signature()))
+            .unwrap();
+        assert_eq!(output, Value::Signature(signature_string!("a(sv)")));
+    }
+
+    #[test]
+    fn serialize_struct() {
+        #[derive(Serialize, Type)]
+        struct MyStruct {
+            a: OwnedObjectPath,
+            b: OwnedSignature,
+        }
+
+        let input = MyStruct {
+            a: ObjectPath::from_static_str_unchecked("/hello").into(),
+            b: Signature::try_from("s").unwrap().into(),
+        };
+
+        let output = input
+            .serialize(ValueSerializer::new(MyStruct::signature()))
+            .unwrap();
+
+        let expected = StructureBuilder::new()
+            .add_field(ObjectPath::from_static_str_unchecked("/hello"))
+            .add_field(signature_string!("s"))
+            .build();
+
+        assert_eq!(output, Value::Structure(expected));
+    }
+
+    #[test]
+    fn serialize_unit_variant() {
+        #[derive(Serialize)]
+        enum SomeStuff {
+            A,
+            B,
+        }
+
+        {
+            let input = SomeStuff::A;
+            let output = input
+                .serialize(ValueSerializer::new(signature_string!("(s)")))
+                .unwrap();
+
+            let expected = StructureBuilder::new().add_field("A").build();
+
+            assert_eq!(output, Value::Structure(expected));
+        }
+
+        {
+            let input = SomeStuff::B;
+            let output = input
+                .serialize(ValueSerializer::new(signature_string!("(s)")))
+                .unwrap();
+
+            let expected = StructureBuilder::new().add_field("B").build();
+
+            assert_eq!(output, Value::Structure(expected));
+        }
+    }
+
+    #[test]
+    fn serialize_newtype_variant() {
+        #[derive(Serialize, Type)]
+        enum MyEnum {
+            A(i32),
+            B(i32),
+        }
+
+        {
+            let input = MyEnum::A(1);
+            let output = input
+                .serialize(ValueSerializer::new(MyEnum::signature()))
+                .unwrap();
+
+            let expected = StructureBuilder::new()
+                .add_field(0u32)
+                .add_field(1i32)
+                .build();
+
+            assert_eq!(output, Value::Structure(expected));
+        }
+
+        {
+            let input = MyEnum::B(2);
+            let output = input
+                .serialize(ValueSerializer::new(MyEnum::signature()))
+                .unwrap();
+
+            let expected = StructureBuilder::new()
+                .add_field(1u32)
+                .add_field(2i32)
+                .build();
+
+            assert_eq!(output, Value::Structure(expected));
+        }
+    }
+
+    #[test]
+    fn serialize_struct_variant() {
+        #[derive(Serialize, Type)]
+        enum MyEnum {
+            A { a: i32, b: String },
+            B { a: i32, b: String },
+        }
+
+        assert_eq!(MyEnum::signature().as_str(), "(u(is))");
+
+        {
+            let input = MyEnum::A {
+                a: 1,
+                b: "hello".into(),
+            };
+            let output = input
+                .serialize(ValueSerializer::new(MyEnum::signature()))
+                .unwrap();
+
+            let expected = StructureBuilder::new()
+                .add_field(0u32)
+                .add_field(1i32)
+                .add_field("hello")
+                .build();
+
+            assert_eq!(output, Value::Structure(expected));
+        }
+
+        {
+            let input = MyEnum::B {
+                a: 2,
+                b: "goodbye".into(),
+            };
+            let output = input
+                .serialize(ValueSerializer::new(MyEnum::signature()))
+                .unwrap();
+
+            let expected = StructureBuilder::new()
+                .add_field(1u32)
+                .add_field(2i32)
+                .add_field("goodbye")
+                .build();
+
+            assert_eq!(output, Value::Structure(expected));
+        }
+    }
+
+    #[test]
+    fn serialize_tuple_variant() {
+        #[derive(Serialize, Type)]
+        enum MyEnum {
+            A(i32, String),
+            B(i32, String),
+        }
+
+        assert_eq!(MyEnum::signature().as_str(), "(u(is))");
+
+        {
+            let input = MyEnum::A(1, "hello".into());
+            let output = input
+                .serialize(ValueSerializer::new(MyEnum::signature()))
+                .unwrap();
+
+            let expected = StructureBuilder::new()
+                .add_field(0u32)
+                .add_field(1i32)
+                .add_field("hello")
+                .build();
+
+            assert_eq!(output, Value::Structure(expected));
+        }
+
+        {
+            let input = MyEnum::B(2, "goodbye".into());
+            let output = input
+                .serialize(ValueSerializer::new(MyEnum::signature()))
+                .unwrap();
+
+            let expected = StructureBuilder::new()
+                .add_field(1u32)
+                .add_field(2i32)
+                .add_field("goodbye")
+                .build();
+
+            assert_eq!(output, Value::Structure(expected));
+        }
+    }
+}

--- a/zvariant/tests/value_serde_roundtrip_test.rs
+++ b/zvariant/tests/value_serde_roundtrip_test.rs
@@ -1,0 +1,268 @@
+use serde::{Deserialize, Serialize};
+use zvariant::{ObjectPath, OwnedValue, Signature, Type};
+
+#[test]
+fn serde_i8() {
+    let value: i8 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: i8 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_i16() {
+    let value: i16 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: i16 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_i32() {
+    let value: i32 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: i32 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_i64() {
+    let value: i64 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: i64 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_u8() {
+    let value: u8 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: u8 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_u16() {
+    let value: u16 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: u16 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_u32() {
+    let value: u32 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: u32 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_u64() {
+    let value: u64 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: u64 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_f64() {
+    let value: f64 = 3.14;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: f64 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_bool() {
+    let value: bool = true;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: bool = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_string() {
+    let value: String = "Hello, world!".to_string();
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: String = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_byte() {
+    let value: u8 = 42;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: u8 = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_char() {
+    let value: char = 'a';
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: char = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_array() {
+    let value: Vec<i32> = vec![1, 2, 3];
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Vec<i32> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_byte_array() {
+    let value: Vec<u8> = vec![1, 2, 3];
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Vec<u8> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_unit_variant() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    enum UnitVariant {
+        A,
+        B,
+    }
+    let value = UnitVariant::A;
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: UnitVariant = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_newtype_struct() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    struct NewtypeStruct(i32);
+    let value = NewtypeStruct(42);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: NewtypeStruct = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_newtype_variant() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    enum NewtypeVariant {
+        A(i32),
+        B(i32),
+    }
+    let value = NewtypeVariant::A(42);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: NewtypeVariant = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_seq() {
+    let value: Vec<i32> = vec![1, 2, 3];
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Vec<i32> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_tuple() {
+    let value: (i32, i32) = (1, 2);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: (i32, i32) = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_tuple_struct() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    struct TupleStruct(i32, i32);
+    let value = TupleStruct(1, 2);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: TupleStruct = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_tuple_variant() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    enum TupleVariant {
+        A(i32, i32),
+        B(i32, i32),
+    }
+    let value = TupleVariant::A(1, 2);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: TupleVariant = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_map() {
+    use std::collections::HashMap;
+    let mut value = HashMap::new();
+    value.insert("a".to_string(), 1);
+    value.insert("b".to_string(), 2);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: HashMap<String, i32> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_struct() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    struct Struct {
+        a: i32,
+        b: i32,
+    }
+    let value = Struct { a: 1, b: 2 };
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Struct = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_struct_variant() {
+    #[derive(Serialize, Deserialize, Type, Debug, PartialEq)]
+    enum StructVariant {
+        A { a: i32, b: i32 },
+        B { a: i32, b: i32 },
+    }
+    let value = StructVariant::A { a: 1, b: 2 };
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: StructVariant = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_object_path() {
+    let value: ObjectPath = ObjectPath::try_from("/org/freedesktop/DBus").unwrap();
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: ObjectPath = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+fn serde_signature() {
+    let value: Signature<'_> = Signature::try_from("a{sv}").unwrap();
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Signature<'_> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+#[cfg(all(feature = "gvariant", not(feature = "option-as-array")))]
+fn test_maybe() {
+    let value: Option<i32> = Some(42);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Option<i32> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}
+
+#[test]
+#[cfg(all(feature = "option-as-array", not(feature = "gvariant")))]
+fn test_maybe() {
+    let value: Option<i32> = Some(42);
+    let serialized: OwnedValue = zvariant::to_value(&value).unwrap();
+    let deserialized: Option<i32> = zvariant::from_value(serialized).unwrap();
+    assert_eq!(value, deserialized);
+}


### PR DESCRIPTION
This change is inspired by similiar functionality in serde-json which allows for types to be serialized/deserialized into an AST directly. This is useful for a variety of reasons, and I think would be of benefit to zbus as well.

Luckily `zvariant` already has a type pretty close to this - the `zvariant::Value`. This thing can represent any value that dbus can represent on the wire. It can also model any variant received from some other service. By serializing and deserializing directly to this thing - it gives clients stronger capability to deal with variants they receive.

Raising this as a draft while I work through broken tests and such.