### PR TITLE
chore: add githooks scripts

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/bash
+GITHOOKS_DIR=$( cd -- "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd )
+source $GITHOOKS_DIR/util.sh
+
+ensure_rustup_installed
+ensure_rustfmt_installed
+
+check_formatting

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,9 @@
+#!/bin/bash
+GITHOOKS_DIR=$( cd -- "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd )
+source $GITHOOKS_DIR/util.sh
+
+ensure_rustup_installed
+ensure_clippy_installed
+
+check_build
+check_clippy

--- a/.githooks/util.sh
+++ b/.githooks/util.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+if test -t 1 && test -n "$(tput colors)" && test "$(tput colors)" -ge 8; then
+	bold="$(tput bold)"
+	normal="$(tput sgr0)"
+	green="$(tput setaf 2)"
+	red="$(tput setaf 1)"
+	blue="$(tput setaf 4)"
+
+	function hook_failure {
+		echo "${red}${bold}FAILED:${normal} ${1}${normal}"
+		exit 1
+	}
+
+	function hook_info {
+		echo "${blue}${1}${normal}"
+	}
+
+	function hook_success {
+		echo "${green}${bold}SUCCESS:${normal} ${1}${normal}"
+		echo
+		echo
+	}
+
+else
+	function hook_failure {
+		echo "FAILED: ${1}"
+		exit 1
+	}
+
+	function hook_info {
+		echo "{$1}"
+	}
+
+	function hook_success {
+		echo "SUCCESS: ${1}"
+		echo
+		echo
+	}
+fi
+
+function ensure_rustup_installed() {
+    hook_info "📦️ Ensuring that rustup is installed"
+    if ! which rustup &> /dev/null; then
+        curl https://sh.rustup.rs -sSf  | sh -s -- -y
+        export PATH=$PATH:$HOME/.cargo/bin
+        if ! which rustup &> /dev/null; then
+            hook_failure "Failed to install rustup"
+        else
+            hook_success "rustup installed."
+        fi
+    else
+        hook_success "rustup is already installed."
+    fi
+}
+
+function ensure_rustfmt_installed() {
+    hook_info "📦️ Ensuring that nightly rustfmt is installed"
+    if ! rustup component list --toolchain nightly|grep 'rustfmt-preview.*(installed)' &> /dev/null; then
+        rustup component add rustfmt-preview --toolchain nightly
+        hook_success "rustfmt installed."
+    else
+        hook_success "rustfmt is already installed."
+    fi
+}
+
+function ensure_clippy_installed() {
+    hook_info "📦️ Ensuring that clippy is installed"
+    if ! rustup component list --toolchain stable|grep 'clippy.*(installed)' &> /dev/null; then
+        rustup component add clippy
+        hook_success "clippy installed."
+    else
+        hook_success "clippy is already installed."
+    fi
+}
+
+function check_build() {
+    hook_info "👷 Running 'cargo build --locked --all-features'"
+    cargo build --locked --all-features \
+        && hook_success "Project builds" \
+        || hook_failure "Cargo could not build the project."
+}
+
+function check_formatting() {
+    hook_info "🎨 Running 'cargo +nightly fmt -- --check'"
+    cargo +nightly fmt -- --check \
+        && hook_success "Project is formatted" \
+        || hook_failure "Cargo format detected errors."
+}
+
+function check_clippy() {
+    hook_info "🔍 Running 'cargo clippy -- -D warnings'"
+    cargo clippy -- -D warnings \
+        && hook_success "Clippy detected no issues" \
+        || hook_failure "Cargo clippy detected errors."
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,65 +89,11 @@ Please note that there are times when clippy is wrong and you know what you are 
 cases, it's acceptable to tell clippy to
 [ignore the specific error or warning in the code](https://github.com/rust-lang/rust-clippy#allowingdenying-lints).
 
-If you intend to contribute often or think that's very likely, we recommend you setup the following git
-hooks:
+You can automate these checks by using this repository git hook scripts. You can enable them with:
 
-* Pre-commit hook that goes in the `.git/hooks/pre-commit` file:
-
-  ```sh
-  if ! which rustup &> /dev/null; then
-      curl https://sh.rustup.rs -sSf  | sh -s -- -y
-      export PATH=$PATH:$HOME/.cargo/bin
-      if ! which rustup &> /dev/null; then
-          echo "Failed to install rustup"
-      fi
-  fi
-
-  if ! rustup component list --toolchain nightly|grep 'rustfmt-preview.*(installed)' &> /dev/null; then
-      echo "Installing nightly rustfmt.."
-      rustup component add rustfmt-preview --toolchain nightly
-      echo "rustfmt installed."
-  fi
-
-  echo "--Checking style--"
-  cargo +nightly fmt --all -- --check
-  if test $? != 0; then
-      echo "--Checking style fail--"
-      echo "Please fix the above issues, either manually or by running: cargo +nightly fmt --all"
-
-      exit -1
-  else
-      echo "--All very stylish 😎--"
-  fi
-  ```
-
-* Pre-push hook that goes in the `.git/hooks/pre-push` file:
-
-  ```sh
-  if ! which rustup &> /dev/null; then
-      curl https://sh.rustup.rs -sSf  | sh -s -- -y
-      export PATH=$PATH:$HOME/.cargo/bin
-      if ! which rustup &> /dev/null; then
-          echo "Failed to install rustup"
-      fi
-  fi
-
-  if ! rustup component list --toolchain stable|grep 'clippy.*(installed)' &> /dev/null; then
-      echo "Installing clippy.."
-      rustup component add clippy
-      echo "clippy installed."
-  fi
-
-  echo "--Analysing code 🔍--"
-  cargo clippy -- -D warnings
-  if test $? != 0; then
-      echo "--Issues with code. See warnings/errors above--"
-
-      exit -1
-  else
-      echo "--Code looks good 👍--"
-  fi
-  ```
+```sh
+git config --local core.hooksPath .githooks/
+```
 
 ## Adding public API
 


### PR DESCRIPTION
This change adds githook scripts to the `.githooks` folder so they can be more trivially enabled by developers working on this repo by using the command `git --local core.hooksPath .githooks/`. They do the same basic function as the scripts documented in `Contributing.md` but with a little extra flair. They also add a step to build and run tests (with `--all-features`) before pushing.